### PR TITLE
common: Notify condition variables while holding lock

### DIFF
--- a/src/latch.cpp
+++ b/src/latch.cpp
@@ -20,8 +20,8 @@ void Latch::decrement() {
         std::lock_guard<std::mutex> lk{m};
         // Prevent potential underflow of `weight`.
         if (weight == 0 || --weight > 0) return;
+        cv.notify_all();
     }
-    cv.notify_all();
 }
 
 void Latch::wait() {

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -24,8 +24,8 @@ bool Worker::enqueue(const std::function<void()>& task) {
         std::lock_guard<std::mutex> lk(m);
         if (terminated) return false;
         work.emplace(task);
+        cv.notify_one();
     }
-    cv.notify_one();
 
     return true;
 }
@@ -35,8 +35,8 @@ void Worker::terminate() {
         std::lock_guard<std::mutex> lk(m);
         if (terminated) return;
         terminated = true;
+        cv.notify_one();
     }
-    cv.notify_one();
 }
 
 } // namespace spindle


### PR DESCRIPTION
It's a common recommendation to notify a condition variable after
releasing the associated lock. The goal being to optimize out pre-mature
wake up of a waiting thread only to find that the lock is unavailable
and then goes back to sleep.

Notifying a condition variable while holding the lock is perfectly valid
and doing otherwise is sometimes incorrect, so do the former.

I noticed this issue in a separate change that benchmarks `ThreadPool`.
While running on macOS, the threads were scheduled in a particular way
and that was accompanied by a spurious wake-up of a condition variable
that ultimately got used after being destroyed. This ultimately caused
the benchmark to hang:
https://github.com/whalbawi/spindle/runs/6083517564