### PR TITLE
common: Clean up various files

### DIFF
--- a/src/latch.cpp
+++ b/src/latch.cpp
@@ -16,12 +16,10 @@ Latch::Latch(uint32_t weight) : weight(weight) {
 }
 
 void Latch::decrement() {
-    {
-        std::lock_guard<std::mutex> lk{m};
-        // Prevent potential underflow of `weight`.
-        if (weight == 0 || --weight > 0) return;
-        cv.notify_all();
-    }
+    std::lock_guard<std::mutex> lk{m};
+    // Prevent potential underflow of `weight`.
+    if (weight == 0 || --weight > 0) return;
+    cv.notify_all();
 }
 
 void Latch::wait() {

--- a/src/latch.h
+++ b/src/latch.h
@@ -27,9 +27,9 @@ class Latch {
     void wait();
 
   private:
-    std::condition_variable cv{};
-    std::mutex m{};
-    uint32_t weight;
+    std::condition_variable cv;
+    std::mutex m;
+    uint32_t weight{};
 };
 
 } // namespace spindle

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -1,12 +1,20 @@
 #include "thread_pool.h"
 
+#include <sstream>
+#include <stdexcept>
+
 #include "worker.h"
 
 namespace spindle {
 
 ThreadPool::ThreadPool() : ThreadPool(std::thread::hardware_concurrency()) {}
 
-ThreadPool::ThreadPool(uint32_t num_threads) {
+ThreadPool::ThreadPool(uint32_t num_threads) : next_worker(0) {
+    if (num_threads <= 0) {
+        std::stringstream s;
+        s << "Thread pool thread count must be positive: " << num_threads;
+        throw std::runtime_error{s.str()};
+    }
     for (int i = 0; i < num_threads; ++i) {
         std::unique_ptr<Worker> worker = std::make_unique<Worker>();
         workers.push_back(std::move(worker));

--- a/src/thread_pool.h
+++ b/src/thread_pool.h
@@ -33,7 +33,7 @@ class ThreadPool {
   private:
     std::vector<std::unique_ptr<Worker>> workers;
     std::vector<std::thread> worker_threads;
-    std::atomic_int next_worker{};
+    std::atomic_int next_worker;
 };
 
 } // namespace spindle

--- a/src/worker.h
+++ b/src/worker.h
@@ -20,9 +20,9 @@ class Worker {
     void terminate();
 
   private:
-    std::queue<std::function<void()>> work{};
-    std::mutex m{};
-    std::condition_variable cv{};
+    std::queue<std::function<void()>> work;
+    std::mutex m;
+    std::condition_variable cv;
     bool terminated{};
 };
 


### PR DESCRIPTION
A previous change modified the scope in which condition variables are
notified. Eliminate duplicate scope braces at these call sites.

Restrict default-initialization of class members to basic types.