### PR TITLE
worker: Introduce deferred task execution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,12 @@ jobs:
     - name: Configure CMake
       env:
         BUILD_TYPE: Release
-      run: cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -B ${{github.workspace}}/build
+        # Do not run deferred task tests on macOS. Performance is bad so the results are unpredictable.
+        SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP: ${{ runner.os == 'macOS' }}
+      run: |
+        cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+              -DSPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP=${SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP} \
+              -B ${{github.workspace}}/build
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ set(SPINDLE_TEST_LIST
     ${SPINDLE_TEST_DIR}/worker_test.cpp
 )
 
+if (NOT DEFINED SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP)
+    option(SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP "Skip worker deferred task tests" OFF)
+endif()
+
 add_library(spindle-lib ${SPINDLE_SRC_LIST})
 target_include_directories(spindle-lib PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gen)
 set_target_properties(spindle-lib PROPERTIES OUTPUT_NAME spindle)
@@ -64,6 +68,9 @@ set_target_properties(spindle-lib PROPERTIES OUTPUT_NAME spindle)
 add_executable(spindle-tests ${SPINDLE_TEST_LIST})
 target_include_directories(spindle-tests PRIVATE ${SPINDLE_SRC_DIR})
 target_link_libraries(spindle-tests spindle-lib gtest_main)
+if (SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP)
+    target_compile_definitions(spindle-tests PRIVATE SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP=1)
+endif()
 
 add_test(unit-tests spindle-tests)
 

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -5,10 +5,34 @@ namespace spindle {
 void Worker::run() {
     for (;;) {
         std::function<void()> task;
-        std::unique_lock<std::mutex> lk(m);
+        std::unique_lock<std::mutex> lk{m};
 
-        cv.wait(lk, [this] { return terminated || !work.empty(); });
+        bool sched_task_due{};
+        // Wait until:
+        // - Terminated
+        // - There is a scheduled task due to run
+        // - There is a task to run
+        // - `cv` times out
+
+        // Note: `cv` will never time out with the predicate evaluating to false. This is because
+        //       The deadline is set if and only if there is scheduled work due.
+        cv.wait_until(lk, deadline, [this, &sched_task_due] {
+            clock::time_point now = clock::now();
+            sched_task_due = !sched_work.empty() && (now > sched_work.top().first);
+            return terminated || sched_task_due || !work.empty();
+        });
+
         if (terminated) return;
+
+        if (sched_task_due) {
+            // Enqueue the task for execution and reset `deadline` if there's scheduled work
+            // remaining
+            work.push(sched_work.top().second);
+            sched_work.pop();
+            deadline = sched_work.empty() ? clock::time_point::max() : sched_work.top().first;
+            sched_task_due = false;
+            continue;
+        }
 
         task = work.front();
         work.pop();
@@ -19,7 +43,7 @@ void Worker::run() {
 }
 
 bool Worker::enqueue(const std::function<void()>& task) {
-    std::lock_guard<std::mutex> lk(m);
+    std::lock_guard<std::mutex> lk{m};
     if (terminated) return false;
     work.emplace(task);
     cv.notify_one();
@@ -28,7 +52,7 @@ bool Worker::enqueue(const std::function<void()>& task) {
 }
 
 void Worker::terminate() {
-    std::lock_guard<std::mutex> lk(m);
+    std::lock_guard<std::mutex> lk{m};
     if (terminated) return;
     terminated = true;
     cv.notify_one();

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,30 +1,54 @@
 #ifndef SPINDLE_WORKER_H_
 #define SPINDLE_WORKER_H_
 
+#include <chrono>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
 #include <queue>
+#include <utility>
 
 namespace spindle {
+
+using clock = std::chrono::high_resolution_clock;
+
+using sched_work_t = std::pair<clock::time_point, std::function<void()>>; // (deadline, task)
+
+// Sort in ascending order of execution time.
+static auto cmp = [](const sched_work_t& x, const sched_work_t& y) { return x.first > y.first; };
 
 // `Worker` continuously executes tasks in a loop, until terminated.
 class Worker {
   public:
     // Continuously executes enqueued tasks until terminated.
     void run();
-    // Enqueue a task for execution.
+    // Enqueues a task for execution.
     bool enqueue(const std::function<void()>& task);
-    // Terminate the `Worker`. From this point onwards, the `Worker` will not reject new tasks
+    // Schedules a task for deferred execution.
+    template <class T> bool schedule(const std::function<void()>& task, T delay);
+    // Terminates the `Worker`. From this point onwards, the `Worker` will not reject new tasks
     // but will continue executing any inflight task.
     void terminate();
 
   private:
     std::queue<std::function<void()>> work;
+    std::priority_queue<sched_work_t, std::vector<sched_work_t>, decltype(cmp)> sched_work{cmp};
     std::mutex m;
     std::condition_variable cv;
+    clock::time_point deadline = clock::time_point::max();
     bool terminated{};
 };
+
+template <class T> bool Worker::schedule(const std::function<void()>& task, T delay) {
+    std::lock_guard<std::mutex> lk{m};
+    if (terminated) return false;
+    clock::time_point task_deadline = clock::now() + delay;
+    sched_work.emplace(task_deadline, task);
+    deadline = std::min(deadline, task_deadline);
+    cv.notify_one();
+
+    return true;
+}
 
 } // namespace spindle
 

--- a/test/worker_test.cpp
+++ b/test/worker_test.cpp
@@ -2,25 +2,72 @@
 
 #include "gtest/gtest.h"
 
+#ifndef SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
+#define SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP 0
+#endif
+
 class WorkerSingleThreadedTest : public ::testing::Test {
   protected:
+    WorkerSingleThreadedTest() : terminator(worker) {}
+
+    bool enqueue(const std::function<void()>& task) {
+        terminator.add_task();
+        // TODO (whalbawi): Figure out why we need to capture `task` by value rather than reference.
+        return worker.enqueue([task, this] {
+            task();
+            terminator();
+        });
+    }
+
+    template <class T> bool schedule(const std::function<void()>& task, T delay) {
+        terminator.add_task();
+        // TODO (whalbawi): Figure out why we need to capture `task` by value rather than reference.
+        return worker.schedule(
+            [task, this] {
+                task();
+                terminator();
+            },
+            delay);
+    }
+
+    template <class S> static std::chrono::milliseconds duration_since(S s) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(spindle::clock::now() - s);
+    }
+
+    class Terminator {
+      public:
+        Terminator(spindle::Worker& worker) : worker(worker) {}
+        void add_task() {
+            num_tasks++;
+        }
+
+        void operator()() {
+            if (--num_tasks == 0) worker.terminate();
+        }
+
+      private:
+        spindle::Worker& worker;
+        int num_tasks{};
+    };
+
     spindle::Worker worker;
+    Terminator terminator;
+    static long delay_tol_pct;
 };
+
+long WorkerSingleThreadedTest::delay_tol_pct = 10; // Being with 10% and tweak as we improve.
 
 TEST_F(WorkerSingleThreadedTest, EnqueueAndTerminate) {
     int x = 0;
-    auto task = [&] {
-        x = 1;
-        worker.terminate();
-    };
+    auto task = [&] { x = 1; };
 
-    ASSERT_EQ(worker.enqueue(task), true);
+    ASSERT_EQ(enqueue(task), true);
     ASSERT_EQ(x, 0); // Enqueuing does not run the task
 
     worker.run();
     ASSERT_EQ(x, 1);
 
-    ASSERT_EQ(worker.enqueue(task), false);
+    ASSERT_EQ(enqueue(task), false);
 }
 
 TEST_F(WorkerSingleThreadedTest, EnqueueMultipleTasks) {
@@ -29,14 +76,11 @@ TEST_F(WorkerSingleThreadedTest, EnqueueMultipleTasks) {
     int z = 0;
     auto task1 = [&] { x = 1; };
     auto task2 = [&] { y = 2; };
-    auto task3 = [&] {
-        z = 3;
-        worker.terminate();
-    };
+    auto task3 = [&] { z = 3; };
 
-    ASSERT_EQ(worker.enqueue(task1), true);
-    ASSERT_EQ(worker.enqueue(task2), true);
-    ASSERT_EQ(worker.enqueue(task3), true);
+    ASSERT_EQ(enqueue(task1), true);
+    ASSERT_EQ(enqueue(task2), true);
+    ASSERT_EQ(enqueue(task3), true);
     // Enqueuing does not run the task
     ASSERT_EQ(x, 0);
     ASSERT_EQ(y, 0);
@@ -47,23 +91,193 @@ TEST_F(WorkerSingleThreadedTest, EnqueueMultipleTasks) {
     ASSERT_EQ(y, 2);
     ASSERT_EQ(z, 3);
 
-    ASSERT_EQ(worker.enqueue(task1), false);
+    ASSERT_EQ(enqueue(task1), false);
 }
 
 TEST_F(WorkerSingleThreadedTest, EnqueueFromEnqueuedTask) {
     int x = 0;
-    auto inner_task = [&] {
-        x = 1;
-        worker.terminate();
-    };
-    auto outer_task = [&] { worker.enqueue(inner_task); };
+    auto inner_task = [&] { x = 1; };
+    auto outer_task = [&] { enqueue(inner_task); };
 
-    ASSERT_EQ(worker.enqueue(outer_task), true);
+    ASSERT_EQ(enqueue(outer_task), true);
     // Enqueuing does not run the task
     ASSERT_EQ(x, 0);
 
     worker.run();
     ASSERT_EQ(x, 1);
 
-    ASSERT_EQ(worker.enqueue(outer_task), false);
+    ASSERT_EQ(enqueue(outer_task), false);
+}
+
+TEST_F(WorkerSingleThreadedTest, DeferredTask) {
+#if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
+    GTEST_SKIP();
+#endif
+    std::chrono::milliseconds delay_ms{100};
+    std::chrono::milliseconds delay;
+
+    spindle::clock::time_point start = spindle::clock::now();
+
+    schedule([&] { delay = duration_since(start); }, delay_ms);
+
+    worker.run();
+
+    long tol = delay_ms.count() * delay_tol_pct / 100;
+    ASSERT_NEAR(delay.count(), delay_ms.count(), tol);
+}
+
+TEST_F(WorkerSingleThreadedTest, ImmediateAndDeferredTask) {
+#if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
+    GTEST_SKIP();
+#endif
+    int x = 0;
+    std::chrono::milliseconds delay_ms{100};
+    std::chrono::milliseconds delay;
+
+    spindle::clock::time_point start = spindle::clock::now();
+
+    schedule(
+        [&] {
+            x++;
+            delay = duration_since(start);
+            ASSERT_EQ(x, 2);
+
+            long tol = delay_ms.count() * delay_tol_pct / 100;
+            ASSERT_NEAR(delay.count(), delay_ms.count(), tol);
+        },
+        delay_ms);
+
+    enqueue([&] {
+        x++;
+        // Even though we enqueued this task second, it should execute first.
+        ASSERT_EQ(x, 1);
+    });
+
+    worker.run();
+}
+
+TEST_F(WorkerSingleThreadedTest, MultipleDeferredTasks) {
+#if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
+    GTEST_SKIP();
+#endif
+
+    int x = 0;
+    std::chrono::milliseconds delay_ms{100};
+    std::chrono::milliseconds delay;
+
+    spindle::clock::time_point start = spindle::clock::now();
+
+    schedule(
+        [&] {
+            x += 1;
+            delay = duration_since(start);
+            ASSERT_EQ(x, 2);
+            long tol = delay_ms.count() * delay_tol_pct / 100;
+            ASSERT_NEAR(delay.count(), delay_ms.count(), tol);
+        },
+        delay_ms);
+
+    enqueue([&] {
+        x += 1;
+        // Even though we enqueued this task second, it should execute first.
+        ASSERT_EQ(x, 1);
+    });
+
+    worker.run();
+}
+
+TEST_F(WorkerSingleThreadedTest, MultipleDeferredAndImmediateTasks) {
+#if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
+    GTEST_SKIP();
+#endif
+
+    int x = 0;
+    std::chrono::milliseconds delay_1_ms{200};
+    std::chrono::milliseconds delay_2_ms{150};
+    std::chrono::milliseconds delay_3_ms{100};
+
+    // ASSERT_FALSE(true);
+    spindle::clock::time_point start = spindle::clock::now();
+    // Position 1
+    enqueue([&] {
+        x++;
+        ASSERT_EQ(x, 1);
+    });
+    // Position 6
+    schedule(
+        [&] {
+            std::chrono::milliseconds delay = duration_since(start);
+            x++;
+            ASSERT_EQ(x, 6);
+            long tol = delay_1_ms.count() * delay_tol_pct / 100;
+            ASSERT_NEAR(delay.count(), delay_1_ms.count(), tol);
+        },
+        delay_1_ms);
+    // Position 2
+    enqueue([&] {
+        x++;
+        ASSERT_EQ(x, 2);
+    });
+    // Position 5
+    schedule(
+        [&] {
+            std::chrono::milliseconds delay = duration_since(start);
+            x++;
+            ASSERT_EQ(x, 5);
+            long tol = delay_2_ms.count() * delay_tol_pct / 100;
+            ASSERT_NEAR(delay.count(), delay_2_ms.count(), tol);
+        },
+        delay_2_ms);
+    // Position 3
+    enqueue([&] {
+        x++;
+        ASSERT_EQ(x, 3);
+    });
+    // Position 4
+    schedule(
+        [&] {
+            std::chrono::milliseconds delay = duration_since(start);
+            x++;
+            ASSERT_EQ(x, 4);
+            long tol = delay_3_ms.count() * delay_tol_pct / 100;
+            ASSERT_NEAR(delay.count(), delay_3_ms.count(), tol);
+        },
+        delay_3_ms);
+    worker.run();
+}
+
+TEST_F(WorkerSingleThreadedTest, RecursiveDeferredTasks) {
+#if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
+    GTEST_SKIP();
+#endif
+
+    int x = 0;
+    std::chrono::milliseconds delay_1_ms{200};
+    std::chrono::milliseconds delay_2_ms{150};
+
+    spindle::clock::time_point start = spindle::clock::now();
+    enqueue([&] {
+        x++;
+        ASSERT_EQ(x, 1);
+    });
+    schedule(
+        [&x, &start, delay_1_ms, delay_2_ms, this] {
+            std::chrono::milliseconds delay = duration_since(start);
+            x++;
+            ASSERT_EQ(x, 2);
+            long tol = delay_1_ms.count() * delay_tol_pct / 100;
+            ASSERT_NEAR(delay.count(), delay_1_ms.count(), tol);
+            start = spindle::clock::now();
+            schedule(
+                [&x, start, delay_2_ms] {
+                    std::chrono::milliseconds delay = duration_since(start);
+                    x++;
+                    ASSERT_EQ(x, 3);
+                    long tol = delay_2_ms.count() * delay_tol_pct / 100;
+                    ASSERT_NEAR(delay.count(), delay_2_ms.count(), tol);
+                },
+                delay_2_ms);
+        },
+        delay_1_ms);
+    worker.run();
 }


### PR DESCRIPTION
Provide the ability to schedule a task for deferred execution. The
scheduled task is stashed into a queue and the thread can continue
processing enqueued tasks. To eliminate spinning, the worker thread goes
to sleep once idle and waits on a condition variable with a timeout
equal to the earliest scheduled task's deadline.

Some tests included in this change check that scheduled work runs within
a reasonable time. These tests are disabled in the macOS GitHub build
job because the runners have poor and unpredictable performance.