### PR TITLE
threadpool: Add a drain capability

### DIFF
--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -31,6 +31,18 @@ void ThreadPool::execute(const std::function<void()>& task) {
     workers[idx]->enqueue(task);
 }
 
+void ThreadPool::drain() {
+    for (auto&& worker : workers) {
+        worker->drain();
+    }
+
+    for (auto&& thread : worker_threads) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+}
+
 void ThreadPool::tear_down() {
     for (auto&& worker : workers) {
         worker->terminate();

--- a/src/thread_pool.h
+++ b/src/thread_pool.h
@@ -27,6 +27,10 @@ class ThreadPool {
     // method concurrently with `ThreadPool::tear_down` does not guarantee execution of the task.
     void execute(const std::function<void()>& task);
 
+    // Puts the `ThreadPool` in a state that prevents scheduling further tasks, and then blocks
+    // until all inflight and queued tasks are executed.
+    void drain();
+
     // Identical to the destructor.
     void tear_down();
 

--- a/test/latch_test.cpp
+++ b/test/latch_test.cpp
@@ -7,7 +7,7 @@
 #include "gtest/gtest.h"
 
 TEST(Latch, InvalidWeight) {
-    EXPECT_THROW(spindle::Latch latch{0}, std::runtime_error);
+    EXPECT_THROW(spindle::Latch{0}, std::runtime_error);
 }
 
 TEST(Latch, WeightOne) {

--- a/test/thread_pool_test.cpp
+++ b/test/thread_pool_test.cpp
@@ -1,7 +1,5 @@
 #include "thread_pool.h"
 
-#include <condition_variable>
-#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -14,16 +12,19 @@ class ThreadPoolTest : public testing::Test {
     spindle::ThreadPool thread_pool{};
 };
 
+TEST_F(ThreadPoolTest, ZeroThreads) {
+    EXPECT_THROW(spindle::ThreadPool{0}, std::runtime_error);
+}
+
 TEST_F(ThreadPoolTest, OneTask) {
     int x = 0;
     spindle::Latch latch{};
 
     thread_pool.execute([&] {
         x = 1;
-        latch.decrement();
     });
 
-    latch.wait();
+    thread_pool.drain();
     ASSERT_EQ(x, 1);
 }
 
@@ -35,11 +36,10 @@ TEST_F(ThreadPoolTest, SingleThreadManyTasks) {
     for (int i = 0; i < task_count; ++i) {
         thread_pool.execute([&, i] {
             x[i] = i;
-            latch.decrement();
         });
     }
 
-    latch.wait();
+    thread_pool.drain();
 
     for (int i = 0; i < task_count; ++i) {
         ASSERT_EQ(x[i], i);
@@ -51,12 +51,11 @@ TEST_F(ThreadPoolTest, MultipleThreadsManyTasks) {
     uint32_t tasks_per_thread = 2048;
     uint32_t task_count = tasks_per_thread * thread_count;
     std::vector<std::thread> threads(thread_count);
+    spindle::Latch latch{thread_count};
     std::vector<uint32_t> x(task_count);
-    spindle::Latch latch{task_count};
 
     auto task = [&](uint32_t pos) {
         x[pos] = pos;
-        latch.decrement();
     };
 
     auto thread_work = [&, tasks_per_thread](int off) {
@@ -69,10 +68,14 @@ TEST_F(ThreadPoolTest, MultipleThreadsManyTasks) {
     };
 
     for (int i = 0; i < thread_count; ++i) {
-        threads[i] = std::thread([&, i] { thread_work(i); });
+        threads[i] = std::thread([&, i] {
+            thread_work(i);
+            latch.decrement();
+        });
     }
 
     latch.wait();
+    thread_pool.drain();
 
     for (int i = 0; i < task_count; ++i) {
         ASSERT_EQ(x[i], i);
@@ -90,9 +93,9 @@ TEST_F(ThreadPoolTest, MultipleThreadsManyTasksRecursiveSchedule) {
     uint32_t tasks_per_thread = 2048;
     uint32_t task_count = tasks_per_thread * thread_count;
     std::vector<std::thread> threads(thread_count);
+    spindle::Latch latch{thread_count};
     std::vector<uint32_t> x(task_count);
     std::vector<uint32_t> y(task_count);
-    spindle::Latch latch{2 * task_count};
 
     auto inner_task = [&](uint32_t pos) {
         thread_pool.execute([&, pos] {
@@ -103,7 +106,6 @@ TEST_F(ThreadPoolTest, MultipleThreadsManyTasksRecursiveSchedule) {
     auto task = [&](uint32_t pos) {
         x[pos] = pos;
         inner_task(pos);
-        latch.decrement();
     };
 
     auto thread_work = [&, tasks_per_thread](int off) {
@@ -120,6 +122,7 @@ TEST_F(ThreadPoolTest, MultipleThreadsManyTasksRecursiveSchedule) {
     }
 
     latch.wait();
+    thread_pool.drain();
 
     for (int i = 0; i < task_count; ++i) {
         ASSERT_EQ(x[i], i);

--- a/test/worker_test.cpp
+++ b/test/worker_test.cpp
@@ -6,9 +6,9 @@
 #define SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP 0
 #endif
 
-class WorkerSingleThreadedTest : public ::testing::Test {
+class WorkerTest : public ::testing::Test {
   protected:
-    WorkerSingleThreadedTest() : terminator(worker) {}
+    WorkerTest() : terminator(worker) {}
 
     bool enqueue(const std::function<void()>& task) {
         terminator.add_task();
@@ -55,9 +55,9 @@ class WorkerSingleThreadedTest : public ::testing::Test {
     static long delay_tol_pct;
 };
 
-long WorkerSingleThreadedTest::delay_tol_pct = 10; // Being with 10% and tweak as we improve.
+long WorkerTest::delay_tol_pct = 10; // Being with 10% and tweak as we improve.
 
-TEST_F(WorkerSingleThreadedTest, EnqueueAndTerminate) {
+TEST_F(WorkerTest, EnqueueAndTerminate) {
     int x = 0;
     auto task = [&] { x = 1; };
 
@@ -70,7 +70,7 @@ TEST_F(WorkerSingleThreadedTest, EnqueueAndTerminate) {
     ASSERT_EQ(enqueue(task), false);
 }
 
-TEST_F(WorkerSingleThreadedTest, EnqueueMultipleTasks) {
+TEST_F(WorkerTest, EnqueueMultipleTasks) {
     int x = 0;
     int y = 0;
     int z = 0;
@@ -94,7 +94,7 @@ TEST_F(WorkerSingleThreadedTest, EnqueueMultipleTasks) {
     ASSERT_EQ(enqueue(task1), false);
 }
 
-TEST_F(WorkerSingleThreadedTest, EnqueueFromEnqueuedTask) {
+TEST_F(WorkerTest, EnqueueFromEnqueuedTask) {
     int x = 0;
     auto inner_task = [&] { x = 1; };
     auto outer_task = [&] { enqueue(inner_task); };
@@ -109,7 +109,7 @@ TEST_F(WorkerSingleThreadedTest, EnqueueFromEnqueuedTask) {
     ASSERT_EQ(enqueue(outer_task), false);
 }
 
-TEST_F(WorkerSingleThreadedTest, DeferredTask) {
+TEST_F(WorkerTest, DeferredTask) {
 #if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
     GTEST_SKIP();
 #endif
@@ -126,7 +126,7 @@ TEST_F(WorkerSingleThreadedTest, DeferredTask) {
     ASSERT_NEAR(delay.count(), delay_ms.count(), tol);
 }
 
-TEST_F(WorkerSingleThreadedTest, ImmediateAndDeferredTask) {
+TEST_F(WorkerTest, ImmediateAndDeferredTask) {
 #if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
     GTEST_SKIP();
 #endif
@@ -156,7 +156,7 @@ TEST_F(WorkerSingleThreadedTest, ImmediateAndDeferredTask) {
     worker.run();
 }
 
-TEST_F(WorkerSingleThreadedTest, MultipleDeferredTasks) {
+TEST_F(WorkerTest, MultipleDeferredTasks) {
 #if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
     GTEST_SKIP();
 #endif
@@ -186,7 +186,7 @@ TEST_F(WorkerSingleThreadedTest, MultipleDeferredTasks) {
     worker.run();
 }
 
-TEST_F(WorkerSingleThreadedTest, MultipleDeferredAndImmediateTasks) {
+TEST_F(WorkerTest, MultipleDeferredAndImmediateTasks) {
 #if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
     GTEST_SKIP();
 #endif
@@ -245,7 +245,7 @@ TEST_F(WorkerSingleThreadedTest, MultipleDeferredAndImmediateTasks) {
     worker.run();
 }
 
-TEST_F(WorkerSingleThreadedTest, RecursiveDeferredTasks) {
+TEST_F(WorkerTest, RecursiveDeferredTasks) {
 #if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
     GTEST_SKIP();
 #endif
@@ -281,7 +281,7 @@ TEST_F(WorkerSingleThreadedTest, RecursiveDeferredTasks) {
     worker.run();
 }
 
-TEST_F(WorkerSingleThreadedTest, PeriodicDeferredTask) {
+TEST_F(WorkerTest, PeriodicDeferredTask) {
 #if SPINDLE_WORKER_DEFERRED_TASK_TESTS_SKIP
     GTEST_SKIP();
 #endif


### PR DESCRIPTION
Provide clients with the ability to "soft" terminate the threadpool:
reject new task submissions but continue to execute inflight and queued
tasks.

Some tests benefit from this revision, so use the feature where
appropriate.