### PR TITLE
worker: Maintain a single queue of work

### DIFF
--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -28,7 +28,7 @@ ThreadPool::~ThreadPool() {
 
 void ThreadPool::execute(const std::function<void()>& task) {
     uint32_t idx = next_worker++ % workers.size(); // No harm in overflowing.
-    workers[idx]->enqueue(task);
+    workers[idx]->schedule(task);
 }
 
 void ThreadPool::drain() {


### PR DESCRIPTION
Simplify `Worker`'s task processing loop by eliminating one of the task
queues. To do so, extend the notion of task deadline's from deferred to
all tasks.

As a result, the public API of `Worker` now has a single method
task scheduling method: `Worker::schedule`.